### PR TITLE
Fetch methods return an Item object

### DIFF
--- a/emcache/__init__.py
+++ b/emcache/__init__.py
@@ -1,4 +1,4 @@
-from .client import Client
+from .client import Client, Item
 from .client_errors import NotStoredStorageCommandError, StorageCommandError
 
-__all__ = ("Client", "StorageCommandError", "NotStoredStorageCommandError")
+__all__ = ("Client", "Item", "StorageCommandError", "NotStoredStorageCommandError")

--- a/tests/acceptance/test_storage_commands.py
+++ b/tests/acceptance/test_storage_commands.py
@@ -222,9 +222,9 @@ class TestPrepend:
         # set the new key and prepend a value.
         await client.set(key_and_value, key_and_value)
         await client.prepend(key_and_value, b"prepend", noreply=True)
-        value_retrieved = await client.get(key_and_value)
+        item = await client.get(key_and_value)
 
-        assert value_retrieved == b"prepend" + key_and_value
+        assert item.value == b"prepend" + key_and_value
 
 
 class TestCas:

--- a/tests/acceptance/test_storage_commands.py
+++ b/tests/acceptance/test_storage_commands.py
@@ -12,40 +12,40 @@ class TestSet:
         key_and_value = next(key_generation)
         await client.set(key_and_value, key_and_value)
 
-        value_retrieved = await client.get(key_and_value)
-        assert value_retrieved == key_and_value
+        item = await client.get(key_and_value)
+        assert item.value == key_and_value
 
     async def test_set_flags(self, client, key_generation):
         key_and_value = next(key_generation)
         await client.set(key_and_value, key_and_value, flags=1)
 
-        value_retrieved, flags_returned = await client.get(key_and_value, return_flags=True)
-        assert value_retrieved == key_and_value
-        assert flags_returned == 1
+        item = await client.get(key_and_value, return_flags=True)
+        assert item.value == key_and_value
+        assert item.flags == 1
 
     async def test_set_exptime(self, client, key_generation):
         key_and_value = next(key_generation)
         await client.set(key_and_value, key_and_value, exptime=-1)
 
-        value_retrieved = await client.get(key_and_value)
+        item = await client.get(key_and_value)
 
-        assert value_retrieved is None
+        assert item is None
 
-    @pytest.mark.skipif(sys.platform == "darwin", reason="should be fixed in the last realease")
+    @pytest.mark.skipif(sys.platform == "darwin", reason="https://github.com/memcached/memcached/issues/681")
     async def test_set_noreply(self, client, key_generation):
         key_and_value = next(key_generation)
         await client.set(key_and_value, key_and_value, noreply=True)
 
-        value_retrieved = await client.get(key_and_value)
-        assert value_retrieved == key_and_value
+        item = await client.get(key_and_value)
+        assert item.value == key_and_value
 
 
 class TestAdd:
     async def test_add(self, client, key_generation):
         key_and_value = next(key_generation)
         await client.add(key_and_value, key_and_value)
-        value_retrieved = await client.get(key_and_value)
-        assert key_and_value == value_retrieved
+        item = await client.get(key_and_value)
+        assert item.value == key_and_value
 
         # adding a new value for the same key must fail
         with pytest.raises(NotStoredStorageCommandError):
@@ -54,27 +54,27 @@ class TestAdd:
     async def test_add_flags(self, client, key_generation):
         key_and_value = next(key_generation)
         await client.add(key_and_value, key_and_value, flags=1)
-        value_retrieved, flags_returned = await client.get(key_and_value, return_flags=True)
+        item = await client.get(key_and_value, return_flags=True)
 
-        assert value_retrieved == key_and_value
-        assert flags_returned == 1
+        assert item.value == key_and_value
+        assert item.flags == 1
 
     async def test_add_exptime(self, client, key_generation):
         key_and_value = next(key_generation)
         await client.add(key_and_value, key_and_value, exptime=-1)
-        value_retrieved = await client.get(key_and_value)
-        assert value_retrieved is None
+        item = await client.get(key_and_value)
+        assert item is None
 
-        # add can be done again
+        # add can be done again and not raises any exception
         await client.add(key_and_value, key_and_value)
 
-    @pytest.mark.skipif(sys.platform == "darwin", reason="should be fixed in the last realease")
+    @pytest.mark.skipif(sys.platform == "darwin", reason="https://github.com/memcached/memcached/issues/681")
     async def test_add_noreply(self, client, key_generation):
         key_and_value = next(key_generation)
         await client.add(key_and_value, key_and_value, noreply=True)
 
-        value_retrieved = await client.get(key_and_value)
-        assert value_retrieved == key_and_value
+        item = await client.get(key_and_value)
+        assert item.value == key_and_value
 
 
 class TestReplace:
@@ -88,9 +88,9 @@ class TestReplace:
         # set the new key and replace the value.
         await client.set(key_and_value, key_and_value)
         await client.replace(key_and_value, b"replace")
-        value_retrieved = await client.get(key_and_value)
+        item = await client.get(key_and_value)
 
-        assert value_retrieved == b"replace"
+        assert item.value == b"replace"
 
     async def test_replace_flags(self, client, key_generation):
         key_and_value = next(key_generation)
@@ -98,10 +98,10 @@ class TestReplace:
         # set the new key and replace the value.
         await client.set(key_and_value, key_and_value)
         await client.replace(key_and_value, b"replace", flags=1)
-        value_retrieved, flags_retrieved = await client.get(key_and_value, return_flags=True)
+        item = await client.get(key_and_value, return_flags=True)
 
-        assert value_retrieved == b"replace"
-        assert flags_retrieved == 1
+        assert item.value == b"replace"
+        assert item.flags == 1
 
     async def test_replace_exptime(self, client, key_generation):
         key_and_value = next(key_generation)
@@ -110,19 +110,19 @@ class TestReplace:
         # for having it expired inmediatly
         await client.set(key_and_value, key_and_value)
         await client.replace(key_and_value, b"replace", exptime=-1)
-        value_retrieved = await client.get(key_and_value)
-        assert value_retrieved is None
+        item = await client.get(key_and_value)
+        assert item is None
 
-    @pytest.mark.skipif(sys.platform == "darwin", reason="should be fixed in the last realease")
+    @pytest.mark.skipif(sys.platform == "darwin", reason="https://github.com/memcached/memcached/issues/681")
     async def test_replace_noreply(self, client, key_generation):
         key_and_value = next(key_generation)
 
         # set the new key and replace the value using noreply
         await client.set(key_and_value, key_and_value)
         await client.replace(key_and_value, b"replace", noreply=True)
-        value_retrieved = await client.get(key_and_value)
+        item = await client.get(key_and_value)
 
-        assert b"replace" == value_retrieved
+        assert item.value == b"replace"
 
 
 class TestAppend:
@@ -136,9 +136,9 @@ class TestAppend:
         # set the new key and append a value.
         await client.set(key_and_value, key_and_value)
         await client.append(key_and_value, b"append")
-        value_retrieved = await client.get(key_and_value)
+        item = await client.get(key_and_value)
 
-        assert value_retrieved == key_and_value + b"append"
+        assert item.value == key_and_value + b"append"
 
     @pytest.mark.xfail
     async def test_append_flags(self, client, key_generation):
@@ -147,10 +147,10 @@ class TestAppend:
         # set the new key and append a value.
         await client.set(key_and_value, key_and_value)
         await client.append(key_and_value, b"append", flags=1)
-        value_retrieved, flags_retrieved = await client.get(key_and_value, return_flags=True)
+        item = await client.get(key_and_value, return_flags=True)
 
-        assert value_retrieved == key_and_value + b"append"
-        assert flags_retrieved == 1
+        assert item.value == key_and_value + b"append"
+        assert item.flags == 1
 
     @pytest.mark.xfail
     async def test_append_exptime(self, client, key_generation):
@@ -160,20 +160,20 @@ class TestAppend:
         # for having it expired inmediately
         await client.set(key_and_value, key_and_value)
         await client.append(key_and_value, b"append", exptime=-1)
-        value_retrieved = await client.get(key_and_value)
+        item = await client.get(key_and_value)
 
-        assert value_retrieved is None
+        assert item is None
 
-    @pytest.mark.skipif(sys.platform == "darwin", reason="should be fixed in the last realease")
+    @pytest.mark.skipif(sys.platform == "darwin", reason="https://github.com/memcached/memcached/issues/681")
     async def test_append_noreply(self, client, key_generation):
         key_and_value = next(key_generation)
 
         # set the new key and append a value.
         await client.set(key_and_value, key_and_value)
         await client.append(key_and_value, b"append", noreply=True)
-        value_retrieved = await client.get(key_and_value)
+        item = await client.get(key_and_value)
 
-        assert value_retrieved == key_and_value + b"append"
+        assert item.value == key_and_value + b"append"
 
 
 class TestPrepend:
@@ -187,9 +187,9 @@ class TestPrepend:
         # set the new key and prepend a value.
         await client.set(key_and_value, key_and_value)
         await client.prepend(key_and_value, b"prepend")
-        value_retrieved = await client.get(key_and_value)
+        item = await client.get(key_and_value)
 
-        assert value_retrieved == b"prepend" + key_and_value
+        assert item.value == b"prepend" + key_and_value
 
     @pytest.mark.xfail
     async def test_prepend_flags(self, client, key_generation):
@@ -198,10 +198,10 @@ class TestPrepend:
         # set the new key and prepend a value.
         await client.set(key_and_value, key_and_value)
         await client.prepend(key_and_value, b"prepend", flags=1)
-        value_retrieved, flags_retrieved = await client.get(key_and_value, return_flags=True)
+        item = await client.get(key_and_value, return_flags=True)
 
-        assert value_retrieved == b"prepend" + key_and_value
-        assert flags_retrieved == 1
+        assert item.value == b"prepend" + key_and_value
+        assert item.flags == 1
 
     @pytest.mark.xfail
     async def test_prepend_exptime(self, client, key_generation):
@@ -211,11 +211,11 @@ class TestPrepend:
         # for having it epxired inmediately
         await client.set(key_and_value, key_and_value)
         await client.prepend(key_and_value, b"prepend", exptime=-1)
-        value_retrieved = await client.get(key_and_value)
+        item = await client.get(key_and_value)
 
-        assert value_retrieved is None
+        assert item.value is None
 
-    @pytest.mark.skipif(sys.platform == "darwin", reason="should be fixed in the last realease")
+    @pytest.mark.skipif(sys.platform == "darwin", reason="https://github.com/memcached/memcached/issues/681")
     async def test_prepend_noreply(self, client, key_generation):
         key_and_value = next(key_generation)
 
@@ -233,24 +233,24 @@ class TestCas:
 
         # Store a new value and retrieve the cas value assigned
         await client.set(key_and_value, key_and_value)
-        _, cas_retrieved = await client.gets(key_and_value)
+        item = await client.gets(key_and_value)
 
         # Swap using the right cas token
-        await client.cas(key_and_value, b"new_value", cas_retrieved)
+        await client.cas(key_and_value, b"new_value", item.cas)
 
         # Check
-        value_retrieved = await client.get(key_and_value)
-        assert value_retrieved == b"new_value"
+        new_item = await client.get(key_and_value)
+        assert new_item.value == b"new_value"
 
     async def test_cas_invalid_cas_token(self, client, key_generation):
         key_and_value = next(key_generation)
 
         # Store a new value and retrieve the cas value assigned
         await client.set(key_and_value, key_and_value)
-        _, cas_retrieved = await client.gets(key_and_value)
+        item = await client.gets(key_and_value)
 
         # Swap using a wrong token cas token
-        wrong_cas_token = cas_retrieved + 1
+        wrong_cas_token = item.cas + 1
         with pytest.raises(NotStoredStorageCommandError):
             await client.cas(key_and_value, b"new_value", wrong_cas_token)
 
@@ -259,42 +259,41 @@ class TestCas:
 
         # Store a new value and retrieve the cas value assigned
         await client.set(key_and_value, key_and_value)
-        _, cas_retrieved = await client.gets(key_and_value)
+        item = await client.gets(key_and_value)
 
         # Swap using the right cas token and upating the flags
-        await client.cas(key_and_value, b"new_value", cas_retrieved, flags=1)
+        await client.cas(key_and_value, b"new_value", item.cas, flags=1)
 
         # Check
-        value_retrieved, flags_retrieved = await client.get(key_and_value, return_flags=True)
-        assert value_retrieved == b"new_value"
-        assert flags_retrieved == 1
+        new_item = await client.get(key_and_value, return_flags=True)
+        assert new_item.value == b"new_value"
+        assert new_item.flags == 1
 
     async def test_cas_exptime(self, client, key_generation):
         key_and_value = next(key_generation)
 
         # Store a new value and retrieve the cas value assigned
         await client.set(key_and_value, key_and_value)
-        _, cas_retrieved = await client.gets(key_and_value)
+        item = await client.gets(key_and_value)
 
         # Swap using the right cas token and updating the exptime
-        await client.cas(key_and_value, b"new_value", cas_retrieved, exptime=-1)
+        await client.cas(key_and_value, b"new_value", item.cas, exptime=-1)
 
         # Check that got expired since we gave an exptime value of -1
-        value_retrieved, flags_retrieved = await client.get(key_and_value, return_flags=True)
-        assert value_retrieved is None
-        assert flags_retrieved is None
+        item = await client.get(key_and_value, return_flags=True)
+        assert item is None
 
-    @pytest.mark.skipif(sys.platform == "darwin", reason="should be fixed in the last realease")
+    @pytest.mark.skipif(sys.platform == "darwin", reason="https://github.com/memcached/memcached/issues/681")
     async def test_cas_noreply(self, client, key_generation):
         key_and_value = next(key_generation)
 
         # Store a new value and retrieve the cas value assigned
         await client.set(key_and_value, key_and_value)
-        _, cas_retrieved = await client.gets(key_and_value)
+        item = await client.gets(key_and_value)
 
         # Swap using the right cas token and no reply
-        await client.cas(key_and_value, b"new_value", cas_retrieved, noreply=True)
+        await client.cas(key_and_value, b"new_value", item.cas, noreply=True)
 
         # Check
-        value_retrieved = await client.get(key_and_value)
-        assert value_retrieved == b"new_value"
+        item = await client.get(key_and_value)
+        assert item.value == b"new_value"


### PR DESCRIPTION
No more tuples with diferent cardinalities, from now all fetch methods
return an Item objec which will have always set the value attribute and
the flags and cas depending on the method called and how this method is
being called.