### PR TITLE
Use a new create_client factory entrypoint

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ Using emcache is as simple as
     >>> import asyncio
     >>> import emcache
     >>> async def main():
-    >>>     client = emcache.Client([('localhost', 11211)])
+    >>>     client = await emcache.create_client([('localhost', 11211)])
     >>>     await client.set(b'key', b'value')
     >>>     item = await client.get(b'key')
     >>>     print(item.value)

--- a/emcache/__init__.py
+++ b/emcache/__init__.py
@@ -1,4 +1,19 @@
-from .client import Client, Item
+from .client import Item, create_client
 from .client_errors import NotStoredStorageCommandError, StorageCommandError
+from .default_values import (
+    DEFAULT_CONNECTION_TIMEOUT,
+    DEFAULT_MAX_CONNECTIONS,
+    DEFAULT_PURGE_UNUSED_CONNECTIONS_AFTER,
+    DEFAULT_TIMEOUT,
+)
 
-__all__ = ("Client", "Item", "StorageCommandError", "NotStoredStorageCommandError")
+__all__ = (
+    "create_client",
+    "DEFAULT_TIMEOUT",
+    "DEFAULT_CONNECTION_TIMEOUT",
+    "DEFAULT_MAX_CONNECTIONS",
+    "DEFAULT_PURGE_UNUSED_CONNECTIONS_AFTER",
+    "Item",
+    "StorageCommandError",
+    "NotStoredStorageCommandError",
+)

--- a/emcache/cluster.py
+++ b/emcache/cluster.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 from ._cython import cyemcache
 from .node import Node
@@ -19,11 +19,20 @@ class Cluster:
     _nodes: List[Node]
     _rdz_nodes: List[cyemcache.RendezvousNode]
 
-    def __init__(self, node_addresses: Sequence[Tuple[str, int]]) -> None:
+    def __init__(
+        self,
+        node_addresses: Sequence[Tuple[str, int]],
+        max_connections: int,
+        purge_unused_connections_after: Optional[float],
+        connection_timeout: Optional[float],
+    ) -> None:
 
         # Create nodes and configure them to be used by the Rendezvous
         # hashing.
-        self._nodes = [Node(host, port) for host, port in node_addresses]
+        self._nodes = [
+            Node(host, port, max_connections, purge_unused_connections_after, connection_timeout)
+            for host, port in node_addresses
+        ]
         self._rdz_nodes = [cyemcache.RendezvousNode(node.host, node.port, node) for node in self._nodes]
 
         logger.debug(f"Cluster configured with {len(self._nodes)} nodes")

--- a/emcache/connection_pool.py
+++ b/emcache/connection_pool.py
@@ -5,7 +5,6 @@ from collections import deque
 from random import randint
 from typing import Dict, Optional
 
-from .default_values import DEFAULT_CONNECTION_TIMEOUT, DEFAULT_MAX_CONNECTIONS, DEFAULT_PURGE_UNUSED_CONNECTIONS_AFTER
 from .protocol import MemcacheAsciiProtocol, create_protocol
 
 logger = logging.getLogger(__name__)
@@ -31,10 +30,9 @@ class ConnectionPool:
         self,
         host: str,
         port: int,
-        *,
-        max_connections: int = DEFAULT_MAX_CONNECTIONS,
-        purge_unused_connections_after: Optional[float] = DEFAULT_PURGE_UNUSED_CONNECTIONS_AFTER,
-        connection_timeout: Optional[float] = DEFAULT_CONNECTION_TIMEOUT,
+        max_connections: int,
+        purge_unused_connections_after: Optional[float],
+        connection_timeout: Optional[float],
     ):
         self._host = host
         self._port = port

--- a/emcache/default_values.py
+++ b/emcache/default_values.py
@@ -1,8 +1,4 @@
 DEFAULT_TIMEOUT = 1.0
-
-# Has been observed that values higher than 32 do not provide
-# a significant increase on the OPS/sec, while higher values could
-# have a negative impact on the latency.
-DEFAULT_MAX_CONNECTIONS = 32
+DEFAULT_MAX_CONNECTIONS = 2
 DEFAULT_CONNECTION_TIMEOUT = 5.0
 DEFAULT_PURGE_UNUSED_CONNECTIONS_AFTER = 60.0

--- a/emcache/node.py
+++ b/emcache/node.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from typing import Optional
 
 from .connection_pool import BaseConnectionContext, ConnectionPool
 
@@ -17,11 +18,20 @@ class Node:
     _connection_pool: ConnectionPool
     _loop: asyncio.AbstractEventLoop
 
-    def __init__(self, host: str, port: int,) -> None:
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        max_connections: int,
+        purge_unused_connections_after: Optional[float],
+        connection_timeout: Optional[float],
+    ) -> None:
         self._host = host
         self._port = port
         self._loop = asyncio.get_running_loop()
-        self._connection_pool = ConnectionPool(host, port)
+        self._connection_pool = ConnectionPool(
+            host, port, max_connections, purge_unused_connections_after, connection_timeout
+        )
         logger.info(f"{self} new node created")
 
     def __str__(self) -> str:

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -2,7 +2,7 @@ import time
 
 import pytest
 
-from emcache import Client
+from emcache import create_client
 
 
 @pytest.fixture
@@ -17,7 +17,7 @@ async def memcached_address_2():
 
 @pytest.fixture
 async def client(event_loop, memcached_address_1, memcached_address_2):
-    return Client([memcached_address_1, memcached_address_2])
+    return await create_client([memcached_address_1, memcached_address_2])
 
 
 @pytest.fixture(scope="session")

--- a/tests/acceptance/test_connectivity.py
+++ b/tests/acceptance/test_connectivity.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from emcache import Client
+from emcache import create_client
 
 pytestmark = pytest.mark.asyncio
 
@@ -10,7 +10,7 @@ UNREACHABLE_HOST = "0.0.0.1"
 
 
 async def test_timeout():
-    client = Client([(UNREACHABLE_HOST, 11211)], timeout=0.1)
+    client = await create_client([(UNREACHABLE_HOST, 11211)], timeout=0.1)
     with pytest.raises(asyncio.TimeoutError):
         await client.get(b"key")
 
@@ -18,7 +18,7 @@ async def test_timeout():
 async def test_timeout_multiple_nodes(memcached_address_1, memcached_address_2):
     # Use two available hosts and one unreachable, everything
     # would need to be cancelled
-    client = Client([memcached_address_1, memcached_address_2, (UNREACHABLE_HOST, 11211)], timeout=0.1)
+    client = await create_client([memcached_address_1, memcached_address_2, (UNREACHABLE_HOST, 11211)], timeout=0.1)
     keys = [str(i).encode() for i in range(100)]
     with pytest.raises(asyncio.TimeoutError):
         await client.get_many(keys)

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1,3 +1,5 @@
+from unittest.mock import call
+
 import pytest
 
 from emcache.cluster import Cluster
@@ -6,8 +8,15 @@ pytestmark = pytest.mark.asyncio
 
 
 class TestCluster:
+    async def test_node_initialization(self, event_loop, mocker):
+        mocker.patch("emcache.cluster.cyemcache")
+        node_class = mocker.patch("emcache.cluster.Node")
+        Cluster([("localhost", 11211), ("localhost", 11212)], 1, 60, 5)
+
+        node_class.assert_has_calls([call("localhost", 11211, 1, 60, 5), call("localhost", 11212, 1, 60, 5)])
+
     async def test_pick_node(self):
-        cluster = Cluster([("localhost", 11211)])
+        cluster = Cluster([("localhost", 11211)], 1, 60, 5)
 
         node = cluster.pick_node(b"key")
         assert node.host == "localhost"

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -12,15 +12,15 @@ def connection_pool(mocker):
 
 class TestNode:
     async def test_host_and_port_properties(self, connection_pool):
-        node = Node("localhost", 11211)
+        node = Node("localhost", 11211, 1, 60, 5)
         assert node.host == "localhost"
         assert node.port == 11211
 
     async def test_str(self, connection_pool):
-        node = Node("localhost", 11211)
+        node = Node("localhost", 11211, 1, 60, 5)
         assert str(node) == "<Node host=localhost port=11211>"
         assert repr(node) == "<Node host=localhost port=11211>"
 
     async def test_connection_pool(self, connection_pool):
-        Node("localhost", 11211)
-        connection_pool.assert_called_with("localhost", 11211)
+        Node("localhost", 11211, 1, 60, 5)
+        connection_pool.assert_called_with("localhost", 11211, 1, 60, 5)


### PR DESCRIPTION
The user must use the new coroutine `create_client` and msut not use
directly the `Client` class.