### PR TITLE
Make Client interface public

### DIFF
--- a/benchmark/sets_gets_stress.py
+++ b/benchmark/sets_gets_stress.py
@@ -7,7 +7,7 @@ from typing import List
 
 import uvloop
 
-from emcache import Client
+from emcache import Client, create_client
 
 uvloop.install()
 
@@ -108,7 +108,7 @@ async def main():
 
     hosts = [(host, int(port)) for host, port in zip(addresses, ports)]
 
-    client = Client(hosts, timeout=None)
+    client = await create_client(hosts, timeout=None, max_connections=args.concurrency)
 
     if args.test == "set_get":
         await benchmark("SET", cmd_set, MAX_NUMBER_OF_KEYS, client, args.concurrency, args.duration)

--- a/emcache/__init__.py
+++ b/emcache/__init__.py
@@ -1,4 +1,5 @@
-from .client import Item, create_client
+from .base_client import Client, Item
+from .client import create_client
 from .client_errors import NotStoredStorageCommandError, StorageCommandError
 from .default_values import (
     DEFAULT_CONNECTION_TIMEOUT,
@@ -8,6 +9,7 @@ from .default_values import (
 )
 
 __all__ = (
+    "Client",
     "create_client",
     "DEFAULT_TIMEOUT",
     "DEFAULT_CONNECTION_TIMEOUT",

--- a/emcache/base_client.py
+++ b/emcache/base_client.py
@@ -1,0 +1,170 @@
+from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass
+from typing import Dict, Optional, Sequence
+
+
+@dataclass
+class Item:
+    value: bytes
+    flags: Optional[int]
+    cas: Optional[int]
+
+
+class Client(metaclass=ABCMeta):
+    @abstractmethod
+    async def get(self, key: bytes, return_flags=False) -> Optional[Item]:
+        """Return the value associated with the key as an `Item` instance.
+
+        If `return_flags` is set to True, the `Item.flags` attribute will be
+        set with the value saved along the value will be returned, otherwise
+        a None value will be set.
+
+        If key is not found, a `None` value will be returned.
+
+        If timeout is not disabled, an `asyncio.TimeoutError` will
+        be returned in case of a timed out operation.
+        """
+
+    @abstractmethod
+    async def gets(self, key: bytes, return_flags=False) -> Optional[Item]:
+        """Return the value associated with the key and its cass value as
+        an `Item` instance.
+
+        If `return_flags` is set to True, the `Item.flags` attribute will be
+        set with the value saved along the value will be returned, otherwise
+        a None value will be set.
+
+        If key is not found, a `None` value will be returned.
+
+        If timeout is not disabled, an `asyncio.TimeoutError` will
+        be returned in case of a timed out operation.
+        """
+
+    @abstractmethod
+    async def get_many(self, keys: Sequence[bytes], return_flags=False) -> Dict[bytes, Item]:
+        """Return the values associated with the keys.
+
+        If a key is not found, the key won't be added to the result.
+
+        More than one request could be sent concurrently to different nodes,
+        where each request will be composed of one or many keys. Hashing
+        algorithm will decide how keys will be grouped by.
+
+        if any request fails due to a timeout - if it is configured - or any other
+        error, all ongoing requests will be automatically canceled and the error will
+        be raised back to the caller.
+        """
+
+    @abstractmethod
+    async def gets_many(self, keys: Sequence[bytes], return_flags=False) -> Dict[bytes, Item]:
+        """Return the values associated with the keys and their cas
+        values.
+
+        Take a look at the `get_many` command for parameters description.
+        """
+
+    @abstractmethod
+    async def set(self, key: bytes, value: bytes, *, flags: int = 0, exptime: int = 0, noreply: bool = False) -> None:
+        """Set a specific value for a given key.
+
+        If command fails a `StorageCommandError` is raised, however
+        when `noreply` option is used there is no ack from the Memcached
+        server, not raising any command error.
+
+        If timeout is not disabled, an `asyncio.TimeoutError` will
+        be returned in case of a timed out operation.
+
+        Other parameters are optional, use them in the following
+        situations:
+
+        - `flags` is an arbitrary 16-bit unsigned integer stored
+        along the value that can be retrieved later with a retrieval
+        command.
+        - `exptime` is the expiration time expressed as an aboslute
+        timestamp. By default, it is set to 0 meaning that the there
+        is no expiration time.
+        - `noreply` when is set memcached will not return a response
+        back telling how the opreation finished, avoiding a full round
+        trip between the client and sever. By using this, the client
+        won't have an explicit way for knowing if the storage command
+        finished correctly. By default is disabled.
+        """
+
+    @abstractmethod
+    async def add(self, key: bytes, value: bytes, *, flags: int = 0, exptime: int = 0, noreply: bool = False) -> None:
+        """Set a specific value for a given key if and only if the key
+        does not already exist.
+
+        If the command fails because the key already exists a
+        `NotStoredStorageCommandError` exception is raised, for other
+        errors the generic `StorageCommandError` is used. However when
+        `noreply` option is used there is no ack from the Memcached
+        server, not raising any command error.
+
+        Take a look at the `set` command for parameters description.
+        """
+
+    @abstractmethod
+    async def replace(
+        self, key: bytes, value: bytes, *, flags: int = 0, exptime: int = 0, noreply: bool = False
+    ) -> None:
+        """Set a specific value for a given key if and only if the key
+        already exists.
+
+        If the command fails because the key was not found a
+        `NotStoredStorageCommandError` exception is raised, for other
+        errors the generic `StorageCommandError` is used. However when
+        `noreply` option is used there is no ack from the Memcached
+        server, not raising any command error.
+
+        Take a look at the `set` command for parameters description.
+        """
+
+    @abstractmethod
+    async def append(
+        self, key: bytes, value: bytes, *, flags: int = 0, exptime: int = 0, noreply: bool = False
+    ) -> None:
+        """Append a specific value for a given key to the current value
+        if and only if the key already exists.
+
+        If the command fails because the key was not found a
+        `NotStoredStorageCommandError` exception is raised, for other
+        errors the generic `StorageCommandError` is used. However when
+        `noreply` option is used there is no ack from the Memcached
+        server, not raising any command error.
+
+        Take a look at the `set` command for parameters description.
+        """
+
+    @abstractmethod
+    async def prepend(
+        self, key: bytes, value: bytes, *, flags: int = 0, exptime: int = 0, noreply: bool = False
+    ) -> None:
+        """Prepend a specific value for a given key to the current value
+        if and only if the key already exists.
+
+        If the command fails because the key was not found a
+        `NotStoredStorageCommandError` exception is raised, for other
+        errors the generic `StorageCommandError` is used. However when
+        `noreply` option is used there is no ack from the Memcached
+        server, not raising any command error.
+
+        Take a look at the `set` command for parameters description.
+        use the documentation of that method.
+        """
+
+    @abstractmethod
+    async def cas(
+        self, key: bytes, value: bytes, cas: int, *, flags: int = 0, exptime: int = 0, noreply: bool = False
+    ) -> None:
+        """Update a specific value for a given key using a cas
+        value, if cas value does not match with the server one
+        command will fail.
+
+        If command fails a `StorageCommandError` is raised, however
+        when `noreply` option is used there is no ack from the Memcached
+        server, not raising any command error.
+
+        Take a look at the `set` command for parameters description.
+        use the documentation of that method.
+        """

--- a/emcache/client.py
+++ b/emcache/client.py
@@ -1,9 +1,9 @@
 import asyncio
 import logging
-from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence, Tuple
 
 from ._cython import cyemcache
+from .base_client import Client, Item
 from .client_errors import NotStoredStorageCommandError, StorageCommandError
 from .cluster import Cluster
 from .default_values import (
@@ -20,13 +20,6 @@ logger = logging.getLogger(__name__)
 
 MAX_ALLOWED_FLAG_VALUE = 2 ** 16
 MAX_ALLOWED_CAS_VALUE = 2 ** 64
-
-
-@dataclass
-class Item:
-    value: bytes
-    flags: Optional[int]
-    cas: Optional[int]
 
 
 class OpTimeout:
@@ -64,7 +57,7 @@ class OpTimeout:
             self._timer_handler.cancel()
 
 
-class Client:
+class _Client(Client):
 
     _cluster: Cluster
     _timeout: Optional[float]
@@ -382,7 +375,7 @@ async def create_client(
     max_connections: int = DEFAULT_MAX_CONNECTIONS,
     purge_unused_connections_after: Optional[float] = DEFAULT_PURGE_UNUSED_CONNECTIONS_AFTER,
     connection_timeout: Optional[float] = DEFAULT_CONNECTION_TIMEOUT,
-) -> None:
+) -> Client:
     """ Factory for creating a new `emcache.Client` instance.
 
     By deafault emcache client will be created with the following default values.
@@ -398,4 +391,4 @@ async def create_client(
     Connection timeout for each new TCP connection, for disabling connection timeout pass a `None` value to the
     `connection_timeout` keyword argument.
     """
-    return Client(node_addresses, timeout, max_connections, purge_unused_connections_after, connection_timeout)
+    return _Client(node_addresses, timeout, max_connections, purge_unused_connections_after, connection_timeout)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY, Mock
 import pytest
 from asynctest import CoroutineMock, MagicMock as AsyncMagicMock
 
-from emcache.client import MAX_ALLOWED_CAS_VALUE, MAX_ALLOWED_FLAG_VALUE, Client, OpTimeout, create_client
+from emcache.client import MAX_ALLOWED_CAS_VALUE, MAX_ALLOWED_FLAG_VALUE, OpTimeout, _Client, create_client
 from emcache.client_errors import StorageCommandError
 from emcache.default_values import (
     DEFAULT_CONNECTION_TIMEOUT,
@@ -79,11 +79,11 @@ class TestClient:
     @pytest.fixture
     async def client(self, event_loop, mocker):
         mocker.patch("emcache.client.Cluster")
-        return Client([("localhost", 11211)], None, 1, None, None)
+        return _Client([("localhost", 11211)], None, 1, None, None)
 
     async def test_invalid_host_addresses(self):
         with pytest.raises(ValueError):
-            Client([], None, 1, None, None)
+            _Client([], None, 1, None, None)
 
     async def test_max_allowed_cas_value(self, client):
         with pytest.raises(ValueError):
@@ -162,7 +162,7 @@ class TestClient:
 
 
 async def test_create_client_default_values(event_loop, mocker):
-    client_class = mocker.patch("emcache.client.Client")
+    client_class = mocker.patch("emcache.client._Client")
     await create_client([("localhost", 11211)])
     client_class.assert_called_with(
         [("localhost", 11211)],


### PR DESCRIPTION
By having the Client as a public interface, not the implementation, we
allow our users to use it as a type.