### PR TITLE
Publish a specific MemcacheHostAddress class

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following snippet shows the minimal stuff that would be needed for creating 
 import asyncio
 import emcache
 async def main():
-    client = await emcache.create_client([('localhost', 11211)])
+    client = await emcache.create_client([emcache.MemcachedHostAddress('localhost', 11211)])
     await client.set(b'key', b'value')
     item = await client.get(b'key')
     print(item.value)

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -12,7 +12,10 @@ For example
 .. code-block:: python
 
     client = await emcache.create_client(
-        [('localhost', 11211), ('localhost', 11212)]
+        [
+            emcache.MemcachedHostAddress('localhost', 11211),
+            emcache.MemcachedHostAddress('localhost', 11212)
+        ]
     )
 
 The previous example would return a :class:`emcache.Client` object instance that will perform the operations to two different Nodes, depending on the outcome of the hashing algorithm,
@@ -35,6 +38,9 @@ Example of a client creation that would purge unused connections
 .. code-block:: python
 
     client = await emcache.create_client(
-        [('localhost', 11211), ('localhost', 11212)],
+        [
+            emcache.MemcachedHostAddress('localhost', 11211),
+            emcache.MemcachedHostAddress('localhost', 11212)
+        ],
         purge_unused_connections_after=60.0
     )

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,8 @@ provided by the :class:`emcache.Client` object.
     import asyncio
     import emcache
     async def main():
-        client = await emcache.create_client([('localhost', 11211)])
+        client = await emcache.create_client(
+            [emcache.MemcachedHostAddress('localhost', 11211)])
         await client.set(b'key', b'value')
         item = await client.get(b'key')
         print(item.value)

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -10,7 +10,7 @@ Following snippet shows how a :meth:`emcache.Client.set` command can be performe
 .. code-block:: python
 
     client = await emcache.create_client(
-        [('localhost', 11211)]
+        [emcache.MemcachedHostAddress('localhost', 11211)]
     )
     await client.set(b"key", b"value")
 

--- a/emcache/__init__.py
+++ b/emcache/__init__.py
@@ -1,6 +1,7 @@
 from .base_client import Client, Item
 from .client import create_client
 from .client_errors import NotStoredStorageCommandError, StorageCommandError
+from .cluster import MemcachedHostAddress
 from .default_values import (
     DEFAULT_CONNECTION_TIMEOUT,
     DEFAULT_MAX_CONNECTIONS,
@@ -16,6 +17,7 @@ __all__ = (
     "DEFAULT_MAX_CONNECTIONS",
     "DEFAULT_PURGE_UNUSED_CONNECTIONS_AFTER",
     "Item",
-    "StorageCommandError",
+    "MemcachedHostAddress",
     "NotStoredStorageCommandError",
+    "StorageCommandError",
 )

--- a/emcache/client.py
+++ b/emcache/client.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Sequence, Tuple
 from ._cython import cyemcache
 from .base_client import Client, Item
 from .client_errors import NotStoredStorageCommandError, StorageCommandError
-from .cluster import Cluster
+from .cluster import Cluster, MemcachedHostAddress
 from .default_values import (
     DEFAULT_CONNECTION_TIMEOUT,
     DEFAULT_MAX_CONNECTIONS,
@@ -65,7 +65,7 @@ class _Client(Client):
 
     def __init__(
         self,
-        node_addresses: Sequence[Tuple[str, int]],
+        node_addresses: Sequence[MemcachedHostAddress],
         timeout: Optional[float],
         max_connections: int,
         purge_unused_connections_after: Optional[float],
@@ -369,7 +369,7 @@ class _Client(Client):
 
 
 async def create_client(
-    node_addresses: Sequence[Tuple[str, int]],
+    node_addresses: Sequence[MemcachedHostAddress],
     *,
     timeout: Optional[float] = DEFAULT_TIMEOUT,
     max_connections: int = DEFAULT_MAX_CONNECTIONS,

--- a/emcache/cluster.py
+++ b/emcache/cluster.py
@@ -1,10 +1,19 @@
 import logging
-from typing import Dict, List, Optional, Sequence, Tuple
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence
 
 from ._cython import cyemcache
 from .node import Node
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MemcachedHostAddress:
+    """ Data class for identifying univocally a Memcached host. """
+
+    address: str
+    port: int
 
 
 class Cluster:
@@ -21,7 +30,7 @@ class Cluster:
 
     def __init__(
         self,
-        node_addresses: Sequence[Tuple[str, int]],
+        node_addresses: Sequence[MemcachedHostAddress],
         max_connections: int,
         purge_unused_connections_after: Optional[float],
         connection_timeout: Optional[float],
@@ -30,8 +39,14 @@ class Cluster:
         # Create nodes and configure them to be used by the Rendezvous
         # hashing.
         self._nodes = [
-            Node(host, port, max_connections, purge_unused_connections_after, connection_timeout)
-            for host, port in node_addresses
+            Node(
+                memcache_host_address.address,
+                memcache_host_address.port,
+                max_connections,
+                purge_unused_connections_after,
+                connection_timeout,
+            )
+            for memcache_host_address in node_addresses
         ]
         self._rdz_nodes = [cyemcache.RendezvousNode(node.host, node.port, node) for node in self._nodes]
 

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -2,17 +2,17 @@ import time
 
 import pytest
 
-from emcache import create_client
+from emcache import MemcachedHostAddress, create_client
 
 
 @pytest.fixture
 async def memcached_address_1():
-    return "localhost", 11211
+    return MemcachedHostAddress("localhost", 11211)
 
 
 @pytest.fixture
 async def memcached_address_2():
-    return "localhost", 11212
+    return MemcachedHostAddress("localhost", 11212)
 
 
 @pytest.fixture

--- a/tests/acceptance/test_connectivity.py
+++ b/tests/acceptance/test_connectivity.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from emcache import create_client
+from emcache import MemcachedHostAddress, create_client
 
 pytestmark = pytest.mark.asyncio
 
@@ -10,7 +10,7 @@ UNREACHABLE_HOST = "0.0.0.1"
 
 
 async def test_timeout():
-    client = await create_client([(UNREACHABLE_HOST, 11211)], timeout=0.1)
+    client = await create_client([MemcachedHostAddress(UNREACHABLE_HOST, 11211)], timeout=0.1)
     with pytest.raises(asyncio.TimeoutError):
         await client.get(b"key")
 
@@ -18,7 +18,9 @@ async def test_timeout():
 async def test_timeout_multiple_nodes(memcached_address_1, memcached_address_2):
     # Use two available hosts and one unreachable, everything
     # would need to be cancelled
-    client = await create_client([memcached_address_1, memcached_address_2, (UNREACHABLE_HOST, 11211)], timeout=0.1)
+    client = await create_client(
+        [memcached_address_1, memcached_address_2, MemcachedHostAddress(UNREACHABLE_HOST, 11211)], timeout=0.1
+    )
     keys = [str(i).encode() for i in range(100)]
     with pytest.raises(asyncio.TimeoutError):
         await client.get_many(keys)

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2,21 +2,28 @@ from unittest.mock import call
 
 import pytest
 
-from emcache.cluster import Cluster
+from emcache.cluster import Cluster, MemcachedHostAddress
 
 pytestmark = pytest.mark.asyncio
+
+
+class TestMemcachedHostAddress:
+    def test_attributes(self):
+        memcached_node = MemcachedHostAddress("localhost", 11211)
+        assert memcached_node.address == "localhost"
+        assert memcached_node.port == 11211
 
 
 class TestCluster:
     async def test_node_initialization(self, event_loop, mocker):
         mocker.patch("emcache.cluster.cyemcache")
         node_class = mocker.patch("emcache.cluster.Node")
-        Cluster([("localhost", 11211), ("localhost", 11212)], 1, 60, 5)
+        Cluster([MemcachedHostAddress("localhost", 11211), MemcachedHostAddress("localhost", 11212)], 1, 60, 5)
 
         node_class.assert_has_calls([call("localhost", 11211, 1, 60, 5), call("localhost", 11212, 1, 60, 5)])
 
     async def test_pick_node(self):
-        cluster = Cluster([("localhost", 11211)], 1, 60, 5)
+        cluster = Cluster([MemcachedHostAddress("localhost", 11211)], 1, 60, 5)
 
         node = cluster.pick_node(b"key")
         assert node.host == "localhost"


### PR DESCRIPTION
This new class will be the way memcahed host addresses will be provided
during the client creation, later on this will allow us to use this
class as a way of idnentifying univocally the nodes of the cluster when
infomration is being returned back to the user regarding node
information.