### PR TITLE
Add support for manylinux1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [maxos-latest, ubuntu-latest]
         python-version: [3.7, 3.8]
 
     runs-on: ${{ matrix.os }}
@@ -21,30 +21,43 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Compile murmur3
+    - name: Generate macos-wheel
+      if: ${{ matrix.os == 'macos-latest' }}
       run: |
         cd vendor/murmur3
         make static
-    - name: Install dependencies
-      run: |
+        cd -
         python -m pip install --upgrade pip
-        make install-dev
-    - name: Memcached dependencies with Mac, by hand
+        make compile
+        python setup.py build bdist_wheel
+    - name: Generate manylinux1-wheel
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        docker run -it -v `pwd`:/io -e "PYTHON_VERSION=${{python-version}}" quay.io/pypa/manylinux1_x86_64 /io/bin/build_manylinux1_wheel.sh
+    - name: Mac acceptance test dependencies
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
         brew install memcached
         memcached -d -p 11211
         memcached -d -p 11212
-    - name: Docker dependencies
+    - name: Linux acceptance test dependencies
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         docker-compose up -d
-    - name: Build release (run the tests)
+    - name: Test generated wheel
       run: |
-        pip install wheel
-        make release
+        mkdir test_wheel
+        cp dist/emcache-*.whl test_wheel
+        cd test_wheel
+        pip install virtualenv
+        python -m virtualenv env
+        source env/bin/activate
+        make -C .. install-dev
+        pip install emcache-*.whl --upgrade
+        make -C .. test
     - name: Publish distribution to Test PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
+        packages_dir: test_wheel/
         password: ${{ secrets.PYPI_TEST_RELEASE_UPLOAD }}
         repository_url: https://test.pypi.org/legacy/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+PYTHON ?= python
+PIP ?= pip
+CYTHON ?= cython
+
 _default: compile
 
 clean:
@@ -6,24 +10,24 @@ clean:
 	find . -type f -name "*.pyc" -delete
 
 .install-cython:
-	pip install Cython==0.29.18
+	$(PIP) install Cython==0.29.18
 	touch .install-cython
 
 emcache/_cython/cyemcache.c: emcache/_cython/cyemcache.pyx
-	cython -3 -o $@ $< -I emcache
+	$(CYTHON) -3 -o $@ $< -I emcache
 
 cythonize: .install-cython emcache/_cython/cyemcache.c
 
 setup-build:
-	python setup.py build_ext --inplace
+	$(PYTHON) setup.py build_ext --inplace
 
 compile: clean cythonize setup-build
 
 install-dev: compile
-	pip install -e ".[dev]"
+	$(PIP) install -e ".[dev]"
 
 install: compile
-	pip install -e .
+	$(PIP) install -e .
 
 format:
 	isort --recursive .
@@ -49,15 +53,13 @@ coverage:
 	coverage report
 
 stress:
-	python benchmark/sets_gets_stress.py --duration 10 --concurrency 32
+	$(PYTHON) benchmark/sets_gets_stress.py --duration 10 --concurrency 32
 
 install-doc:
-	pip install -r docs/requirements.txt
+	$(PIP) install -r docs/requirements.txt
 
 doc:
 	make -C docs/ html
 
-release: compile test
-	python setup.py sdist bdist_wheel
 
 .PHONY: clean setup-build install install-dev compile unit test acceptance stress

--- a/bin/build_manylinux1_wheel.sh
+++ b/bin/build_manylinux1_wheel.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ $PYTHON_VERSION == "3.7" ]
+then
+    PYTHON=/opt/python/cp37-cp37m/bin/python
+    PIP=/opt/python/cp37-cp37m/bin/pip
+    CYTHON=/opt/python/cp37-cp37m/bin/cython
+    AUDITWHEEL=/opt/python/cp37-cp37m/bin/auditwheel
+elif [ $PYTHON_VERSION == "3.8" ]
+then
+    PYTHON=/opt/python/cp38-cp38/bin/python
+    PIP=/opt/python/cp38-cp38/bin/pip
+    CYTHON=/opt/python/cp38-cp38/bin/cython
+    AUDITWHEEL=/opt/python/cp38-cp38/bin/auditwheel
+else
+    exit 1
+fi
+
+cd /io/vendor/murmur3
+make static
+cd /io
+${PYTHON} -m pip install --upgrade pip
+${PIP} install auditwheel
+PYTHON=${PYTHON} PIP=${PIP} CYTHON=${CYTHON} make compile
+${PYTHON} setup.py build bdist_wheel
+${AUDITWHEEL} repair dist/emcache-*.whl -w dist
+rm dist/emcache-*-linux*

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,4 @@ include_trailing_comma = True
 force_grid_wrap = 0
 combine_as_imports = True
 line_length = 120
-skip = .eggs,.venv,venv
+skip = .eggs,.venv,venv,benchmark

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ dev_requires = [
     "pytest==5.4.1",
     "pytest-mock==3.1.0",
     "pytest-asyncio==0.11.0",
-    "uvloop==0.14.0",
     "asynctest==0.13.0",
     "pytest-cov==2.8.1",
     "black==19.10b0",


### PR DESCRIPTION
Pypi forces to upload packages that are compatible with all linux, we
have modified the release workflow following the instruction for
compiling a wheel that would need to be compatible for any linux.

Because of that the release workflow has changed a bit, and Mac and
Linux follow two different paths for compiling the wheel.

Once the wheel is generated we test it by installing it into a new
environment.