### PR TITLE
Keep 1 TCP connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+IN PROGRESS 0.2.0b0
+===================
+- Try to have always at least one TCP connection per host.
+- Quadratic backoff until reach the maximum of 60 seconds when an attempt for openning a connection
+  fails.
+
 0.1.1b0
 =======
 - Disabled support for `exptime` and `flags` for the `append` and `prepend` commands. For both commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 IN PROGRESS 0.2.0b0
 ===================
-- Try to have always at least one TCP connection per host.
+- Try to have always at least one TCP connection per host. [#26](https://github.com/pfreixes/emcache/pull/26)
 - Quadratic backoff until reach the maximum of 60 seconds when an attempt for openning a connection
-  fails.
+  fails. [#26](https://github.com/pfreixes/emcache/pull/26)
 
 0.1.1b0
 =======

--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -65,3 +65,6 @@ a single client instance:
 
 Any number beyond 32 TCP connections did not have a significant increase in the number of operations per second. By default, the connection pool comes configured with 2 maximum TCP connections,
 which should provide in a modern CPU ~20K ops/sec.
+
+Any provided number must be higher than 0, otherwise a :exc:`ValueError` will be raised. The connection pool will try to keep always at least one TCP connection opened even when there is no traffic.
+Purging will not be applied for the last and unique TCP connection available.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,6 @@ line-length = 120
 exclude = '''
 /(
     \.eggs
-  | \.venv
+  | \env
 )/
 '''

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 120
-exclude = .eggs,.venv,venv
+exclude = .eggs,env
 #ignore = E121,E123,E126,E226,E24,E704,W503,W504,E203
 
 [pep8]
@@ -23,4 +23,4 @@ include_trailing_comma = True
 force_grid_wrap = 0
 combine_as_imports = True
 line_length = 120
-skip = .eggs,.venv,venv,benchmark
+skip = .eggs,env,benchmark


### PR DESCRIPTION
Connection pool will try to keep always at least 1 TCP connection, this
means that when connection pool is started a new connection is
automatically created. Purging won't consider the last TCP connection as
an unused one, so having it always openned.