### PR TITLE
Cluster managment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ IN PROGRESS 0.2.0b0
 - Support for cluster events for telling you in real time what signfificant events are happening,
   for now only supports two events for telling you when a node has changed the healthy status. [#27](https://github.com/pfreixes/emcache/pull/27)
 - Support for cluster managment which provies different operations for the cluster like listing the nodes
-  that are participating into the cluster, or return the ones that are healthy or unhealthy.
+  that are participating into the cluster, or return the ones that are healthy or unhealthy. [#29](https://github.com/pfreixes/emcache/pull/29)
 
 0.1.1b0
 =======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ IN PROGRESS 0.2.0b0
   traffic. [#27](https://github.com/pfreixes/emcache/pull/27)
 - Support for cluster events for telling you in real time what signfificant events are happening,
   for now only supports two events for telling you when a node has changed the healthy status. [#27](https://github.com/pfreixes/emcache/pull/27)
+- Support for cluster managment which provies different operations for the cluster like listing the nodes
+  that are participating into the cluster, or return the ones that are healthy or unhealthy.
 
 0.1.1b0
 =======

--- a/docs/cluster_managment.rst
+++ b/docs/cluster_managment.rst
@@ -1,0 +1,42 @@
+Cluster Managment
+-----------------
+
+Emcache provides a public interface for making different cluster opeations, by calling the method :meth:`emcache.Client.cluster_managment` an instance of a :class:`emcache.ClusterManagment`
+will be returned, the instance returned will use behind the scenes the cluster - for example nodes and configuration - that were provided for creating the :class:`CLient` instance.
+
+Following example shows how an instance of :class:`emcache.ClusterManagment` can be retrieved:
+
+.. code-block:: python
+
+    client = await emcache.create_client(
+        [
+            emcache.MemcachedHostAddress('localhost', 11211),
+            emcache.MemcachedHostAddress('localhost', 11212)
+        ]
+    )
+    client.cluster_managment().nodes()
+
+
+We might be interested on provide an intermediate factory for creating a client cache that will retrieve the cluster managment instance for using it later, for example:
+
+.. code-block:: python
+
+    async def create_client_cache() -> emcache.Client:
+        global cache_cluster_managment
+        client = await emcache.create_client(
+            [
+                emcache.MemcachedHostAddress('localhost', 11211),
+                emcache.MemcachedHostAddress('localhost', 11212)
+            ]
+        )
+        cache_cluster_managment = client.cluster_managment()
+        return client
+
+:class:`emcache.ClusterManagment` provides the following methods:
+
+- :meth:`emcache.ClusterManagment.nodes` Returns the list of nodes that belong to the cluster, where each node is a :class:`emcache.MemcachedHostAddress`.
+- :meth:`emcache.ClusterManagment.healthy_nodes` Returns the list of nodes that belong to the cluster that are considered healthy, where each node is a :class:`emcache.MemcachedHostAddress`. Take a look to
+  the advanced options chapter and more specifically at the Healty and Unhealthy nodes for understanding what node healthiness means.
+- :meth:`emcache.ClusterManagment.unhealthy_nodes` Returns the list of nodes that belong to the cluster that are considered unhealthy, where each node is a :class:`emcache.MemcachedHostAddress`. Take a look to
+  the advanced options chapter and more specifically at the Healty and Unhealthy nodes for understanding what node healthiness means.
+-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,4 +46,5 @@ Contents
 
   client
   operations
+  cluster_managment
   advanced_topics

--- a/emcache/__init__.py
+++ b/emcache/__init__.py
@@ -1,4 +1,4 @@
-from .base import Client, ClusterEvents, Item
+from .base import Client, ClusterEvents, ClusterManagment, Item
 from .client import create_client
 from .client_errors import ClusterNoAvailableNodes, NotStoredStorageCommandError, StorageCommandError
 from .default_values import (
@@ -13,6 +13,7 @@ from .node import MemcachedHostAddress
 __all__ = (
     "Client",
     "ClusterEvents",
+    "ClusterManagment",
     "ClusterNoAvailableNodes",
     "create_client",
     "DEFAULT_TIMEOUT",

--- a/emcache/base.py
+++ b/emcache/base.py
@@ -181,7 +181,7 @@ class ClusterEvents(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    async def on_node_healthy(self, host: MemcachedHostAddress) -> None:
+    def on_node_healthy(self, host: MemcachedHostAddress) -> None:
         """Called when a node is marked as healthy.
 
         A node is marked as healthy when there is at least one TCP
@@ -189,7 +189,7 @@ class ClusterEvents(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    async def on_node_unhealthy(self, host: MemcachedHostAddress) -> None:
+    def on_node_unhealthy(self, host: MemcachedHostAddress) -> None:
         """Called when a new node is marked as umhealthy.
 
         A node is marked as unhealthy when there is no TCP
@@ -204,3 +204,33 @@ class ClusterEvents(metaclass=ABCMeta):
         These event will be fired in any circumstance without depending on
         the value of the `purge_unhealthy_nodes` value.
         """
+
+
+class ClusterManagment(metaclass=ABCMeta):
+    """ ClusterManagment provides you the public interface
+    for managing the cluster.
+
+    A `Client` instance proides you a way for having access
+    to an instance of `ClusterManagment` related to the cluster
+    used for that specific client, as the following example
+    shows:
+
+        >>> client = await emcache.create_client(...)
+        >>> cluster_managment = client.cluster_managment()
+        >>> print(cluster_managment.nodes())
+
+    Take a look to the different methods for knowing what operations
+    are currently supported.
+    """
+
+    @abstractmethod
+    def nodes(self) -> Sequence[MemcachedHostAddress]:
+        """Return the nodes that belong to the cluster. """
+
+    @abstractmethod
+    def healthy_nodes(self) -> Sequence[MemcachedHostAddress]:
+        """Return the nodes that are considered healthy. """
+
+    @abstractmethod
+    def unhealthy_nodes(self) -> Sequence[MemcachedHostAddress]:
+        """Return the nodes that are considered unhealthy. """

--- a/emcache/client.py
+++ b/emcache/client.py
@@ -3,7 +3,7 @@ import logging
 from typing import Dict, List, Optional, Sequence, Tuple
 
 from ._cython import cyemcache
-from .base import Client, ClusterEvents, Item
+from .base import Client, ClusterEvents, ClusterManagment, Item
 from .client_errors import NotStoredStorageCommandError, StorageCommandError
 from .cluster import Cluster, MemcachedHostAddress
 from .default_values import (
@@ -150,6 +150,14 @@ class _Client(Client):
                 raise
 
         return [task.result() for task in tasks]
+
+    def cluster_managment(self) -> ClusterManagment:
+        """ Returns the `ClusterMangment` instance class for managing
+        the cluster related to that client.
+
+        Same instance is returned at any call.
+        """
+        return self._cluster.cluster_managment
 
     async def get(self, key: bytes, return_flags=False) -> Optional[Item]:
         """Return the value associated with the key as an `Item` instance.

--- a/tests/acceptance/test_cluster_managment.py
+++ b/tests/acceptance/test_cluster_managment.py
@@ -1,0 +1,14 @@
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestClusterManagment:
+    async def test_nodes(self, client, memcached_address_1, memcached_address_2):
+        assert client.cluster_managment().nodes() == [memcached_address_1, memcached_address_2]
+
+    async def test_healthy_nodes(self, client, memcached_address_1, memcached_address_2):
+        assert client.cluster_managment().healthy_nodes() == [memcached_address_1, memcached_address_2]
+
+    async def test_unhealthy_nodes(self, client, memcached_address_1, memcached_address_2):
+        assert client.cluster_managment().unhealthy_nodes() == []


### PR DESCRIPTION
This commit introduces the `ClusterManagment` interface, which
can be retrieved by using the `Client.cluster_managment()` method. This
interface for now provices methods for returning the list of the nodes
that are participating into the cluster and the list of nodes that are
considered healthy and unhealthy.