### PR TITLE
Connection Pool metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ IN PROGRESS 0.2.0b0
   for now only supports two events for telling you when a node has changed the healthy status. [#27](https://github.com/pfreixes/emcache/pull/27)
 - Support for cluster managment which provies different operations for the cluster like listing the nodes
   that are participating into the cluster, or return the ones that are healthy or unhealthy. [#29](https://github.com/pfreixes/emcache/pull/29)
+- New cluster managment function for returning the most important metrics observed at connection pool
+  level [#30](https://github.com/pfreixes/emcache/pull/30)
 
 0.1.1b0
 =======

--- a/docs/cluster_managment.rst
+++ b/docs/cluster_managment.rst
@@ -39,4 +39,23 @@ We might be interested on provide an intermediate factory for creating a client 
   the advanced options chapter and more specifically at the Healty and Unhealthy nodes for understanding what node healthiness means.
 - :meth:`emcache.ClusterManagment.unhealthy_nodes` Returns the list of nodes that belong to the cluster that are considered unhealthy, where each node is a :class:`emcache.MemcachedHostAddress`. Take a look to
   the advanced options chapter and more specifically at the Healty and Unhealthy nodes for understanding what node healthiness means.
--
+- :meth:`emcache.ClusterManagment.connection_pool_metrics` Returns the most important metrics that have been observed per each connection pool, take a look to the following section for understanding what
+  metrics are being reported.
+
+Connection pool metrics
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The :meth:`emcache.ClusterManagment.connection_pool_metrics` method returns the main metrics observed by each connection pool of each of the cluster nodes. A dictionary having as
+a key the :class:`emcache.MemcachedHostAddress` class instances representing each node, and as a value an instance of :class:`emcache.ConnectionPoolMetrics`. The metrics that are
+returned as attributes of this class are:
+
+- **curr_connections** Tells you how many connections are oppened at that specific moment.
+- **connections_created** Tells you how many connections have been created until now.
+- **connections_created_with_error** Tells you how many connections have been created but ended up by having an exception during the creation time.
+- **connections_purged** Tells you how many connections have been purged.
+- **connections_closed** Tells you how many connections have been closed.
+- **operations_executed** Tells you how many operations have been executed.
+- **operations_executed_with_error** Tells you how many operations have been executed but ended up by having an exception during the execution.
+- **operations_waited** Tells you how many operations were delayed becausew they had to wait for an available connection.
+
+These metrics can be push to a time series database for monitoring the execution of the Emcache driver, the user will need to take care of calculating the deltas, if the user is intereseted on them, of each historical value since historical values are accumulated values.

--- a/emcache/__init__.py
+++ b/emcache/__init__.py
@@ -1,6 +1,7 @@
 from .base import Client, ClusterEvents, ClusterManagment, Item
 from .client import create_client
 from .client_errors import ClusterNoAvailableNodes, NotStoredStorageCommandError, StorageCommandError
+from .connection_pool import ConnectionPoolMetrics
 from .default_values import (
     DEFAULT_CONNECTION_TIMEOUT,
     DEFAULT_MAX_CONNECTIONS,
@@ -15,6 +16,7 @@ __all__ = (
     "ClusterEvents",
     "ClusterManagment",
     "ClusterNoAvailableNodes",
+    "ConnectionPoolMetrics",
     "create_client",
     "DEFAULT_TIMEOUT",
     "DEFAULT_CONNECTION_TIMEOUT",

--- a/emcache/node.py
+++ b/emcache/node.py
@@ -3,12 +3,12 @@ import logging
 from dataclasses import dataclass
 from typing import Callable, Optional
 
-from .connection_pool import BaseConnectionContext, ConnectionPool
+from .connection_pool import BaseConnectionContext, ConnectionPool, ConnectionPoolMetrics
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(frozen=True)
 class MemcachedHostAddress:
     """ Data class for identifying univocally a Memcached host. """
 
@@ -73,6 +73,9 @@ class Node:
 
     def connection(self) -> BaseConnectionContext:
         return self._connection_pool.create_connection_context()
+
+    def connection_pool_metrics(self) -> ConnectionPoolMetrics:
+        return self._connection_pool.metrics()
 
     @property
     def host(self) -> str:

--- a/tests/acceptance/test_cluster_managment.py
+++ b/tests/acceptance/test_cluster_managment.py
@@ -1,5 +1,7 @@
 import pytest
 
+from emcache import ConnectionPoolMetrics
+
 pytestmark = pytest.mark.asyncio
 
 
@@ -12,3 +14,11 @@ class TestClusterManagment:
 
     async def test_unhealthy_nodes(self, client, memcached_address_1, memcached_address_2):
         assert client.cluster_managment().unhealthy_nodes() == []
+
+    async def test_connection_pool_metrics(self, client, memcached_address_1, memcached_address_2):
+        metrics = client.cluster_managment().connection_pool_metrics()
+
+        # just check that both nodes appear in the dictionary returned, more accurated
+        # tests for metrics attributes are done as unit tests
+        assert isinstance(metrics[memcached_address_1], ConnectionPoolMetrics)
+        assert isinstance(metrics[memcached_address_2], ConnectionPoolMetrics)


### PR DESCRIPTION
Added a new cluster managment method for retrieving the most important
metrics reported by each connection pool, among them number of
connections, historical number of connections created, etc