### PR TITLE
Cluster event hooks are coroutines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ IN PROGRESS 0.2.0b0
   one TCP connection. Unhealthy nodes can be optionally removed from pool of nodes elegible for sending
   traffic. [#27](https://github.com/pfreixes/emcache/pull/27)
 - Support for cluster events for telling you in real time what signfificant events are happening,
-  for now only supports two events for telling you when a node has changed the healthy status. [#27](https://github.com/pfreixes/emcache/pull/27)
+  for now only supports two events for telling you when a node has changed the healthy status. [#27](https://github.com/pfreixes/emcache/pull/27)[#32](https://github.com/pfreixes/emcache/pull/32)
 - Support for cluster managment which provies different operations for the cluster like listing the nodes
   that are participating into the cluster, or return the ones that are healthy or unhealthy. [#29](https://github.com/pfreixes/emcache/pull/29)
 - New cluster managment function for returning the most important metrics observed at connection pool

--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -109,10 +109,10 @@ Following example shows how this parameter can be provided:
 
     class ClusterEvents(emcache.ClusterEvents):
 
-        def on_node_healthy(self, memcached_host_address):
+        async def on_node_healthy(self, cluster_managment, memcached_host_address):
             print(f"Node {memcached_host_address} reports a healthy status")
 
-        def on_node_unhealthy(self, memcached_host_address):
+        async def on_node_unhealthy(self, cluster_managment, memcached_host_address):
             print(f"Node {memcached_host_address} reports an unhealthy status")
 
     client = await emcache.create_client(
@@ -124,4 +124,7 @@ Following example shows how this parameter can be provided:
     )
 
 Right now :class:`ClusterEvents` has only support for reporting events realated to changes of the node healthiness, the two hooks :meth:`on_node_healthy` and :meth:`on_node_unhealthy` would be
-called - independntly of the `purge_unhealthy_nodes` configuration - when one of the nodes of the cluster change the healthy status.
+called - independntly of the `purge_unhealthy_nodes` configuration - when one of the nodes of the cluster change the healthy status. Besides of the argument for identifying univocally the node that is related
+to a specifice event, as a first argument the :class:`ClusterManagment` instance will be provided which might be used for retrieving more information about the cluster and its nodes.
+
+Events are dispatched in serie, meaning that behind the scenes Emcache will be calling one and only one hook at any moment, and order of the events will be guaranteed. The hook, due to the asynchronous nature might decide to run asynchronous operations, this might delay the delivery of pending messages. 

--- a/emcache/base.py
+++ b/emcache/base.py
@@ -181,7 +181,7 @@ class ClusterEvents(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def on_node_healthy(self, host: MemcachedHostAddress) -> None:
+    async def on_node_healthy(self, cluster_managment: "ClusterManagment", host: MemcachedHostAddress) -> None:
         """Called when a node is marked as healthy.
 
         A node is marked as healthy when there is at least one TCP
@@ -189,7 +189,7 @@ class ClusterEvents(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def on_node_unhealthy(self, host: MemcachedHostAddress) -> None:
+    async def on_node_unhealthy(self, cluster_managment: "ClusterManagment", host: MemcachedHostAddress) -> None:
         """Called when a new node is marked as umhealthy.
 
         A node is marked as unhealthy when there is no TCP


### PR DESCRIPTION
Move from single functions to coroutines, which would allow the user to
a richer behaviour within the loop and considering that the events would
happen theoretically from time to time, in any case for avoid pause the
emcache driver the events are dispathed in a separated task.