### PR TITLE
Add support for flush all operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 =====================
 - Add support for the `increment` and `decrement` commands [#36](https://github.com/pfreixes/emcache/pull/36)
 - Add support for the `touch` command [#37](https://github.com/pfreixes/emcache/pull/37)
+- Add support for `flush_all` command
 
 0.2.1b0
 =======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 =====================
 - Add support for the `increment` and `decrement` commands [#36](https://github.com/pfreixes/emcache/pull/36)
 - Add support for the `touch` command [#37](https://github.com/pfreixes/emcache/pull/37)
-- Add support for `flush_all` command
+- Add support for `flush_all` command [#38](https://github.com/pfreixes/emcache/pull/38)
 
 0.2.1b0
 =======

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -117,6 +117,7 @@ For having access to the flags, the ``return_flags`` keyword would need to be se
 
 The :meth:`emcache.Client.gets_many` and :meth:`emcache.Client.get_many` operations return a dictionary of the keys found, having as a value
 the :class:`emcache.Item` of each key. For example:
+
 .. code-block:: python
 
     await for key, item in client.get_many([b"key", b"key2"]).items():
@@ -133,4 +134,22 @@ Emcache has also support for the following other commands:
 - :meth:`emcache.Client.increment` Increases an already existing key by a value.
 - :meth:`emcache.Client.decrement` Decreases an already existing key by a value.
 - :meth:`emcache.Client.touch` Overrides the expiration time of an already existing key.
--
+- :meth:`emcache.Client.flush_all` Flush all keys from an existing node, see notes below.
+
+The :meth:`emcache.Client.flush_all` method targets a specific node, so the parameter expected is the :meth:`emcache.MemcachedHostAddress` which
+identifies univocally a memcached host within the cluster. Also, a parameter called ``delay`` is supported for telling to the Memcached server that the
+expiration of all of the keys should be done after a specific period of time. This option allows for example to delay the expiration of the keys
+for each node in a different moment of time, which should help you on the way for mitigating the likely load that underlying resources might get because
+of the increase of misses.
+
+As an example, the following snippet shows how :meth:`emcache.Client.flush_all` can be used:
+
+.. code-block:: python
+
+    hosts = [
+        emcache.MemcachedHostAddress('localhost', 11211),
+        emcache.MemcachedHostAddress('localhost', 11212)
+    ]
+
+    for idx, host in enum(hosts):
+        await client.flush_all(host, delay=10 + (10*idx))

--- a/emcache/cluster.py
+++ b/emcache/cluster.py
@@ -203,6 +203,14 @@ class Cluster:
 
         return cyemcache.nodes_selection(keys, self._rdz_nodes)
 
+    def node(self, memcached_host_address: MemcachedHostAddress) -> Node:
+        """Return the emcache Node that matches with a memcached_host_address."""
+        for node in self.nodes:
+            if node.memcached_host_address == memcached_host_address:
+                return node
+
+        raise ValueError(f"{memcached_host_address} can not be found")
+
     @property
     def cluster_managment(self) -> ClusterManagment:
         return self._cluster_managment

--- a/emcache/protocol.py
+++ b/emcache/protocol.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 EXISTS = b"EXISTS"
 STORED = b"STORED"
 TOUCHED = b"TOUCHED"
+OK = b"OK"
 NOT_STORED = b"NOT_STORED"
 NOT_FOUND = b"NOT_FOUND"
 
@@ -161,6 +162,30 @@ class MemcacheAsciiProtocol(asyncio.Protocol):
             noreply = b""
 
         data = b"touch " + key + b" " + str(exptime).encode() + noreply + b"\r\n"
+
+        if noreply:
+            # fire and forget
+            self._transport.write(data)
+            return None
+
+        try:
+            future = self._loop.create_future()
+            parser = cyemcache.AsciiOneLineParser(future)
+            self._parser = parser
+            self._transport.write(data)
+            await future
+            result = parser.value()
+            return result
+        finally:
+            self._parser = None
+
+    async def flush_all_command(self, delay: int, noreply: bool) -> Optional[bytes]:
+        if noreply:
+            noreply = b" noreply"
+        else:
+            noreply = b""
+
+        data = b"flush_all " + str(delay).encode() + noreply + b"\r\n"
 
         if noreply:
             # fire and forget

--- a/tests/acceptance/test_other_commands.py
+++ b/tests/acceptance/test_other_commands.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 
 import pytest
@@ -90,5 +91,44 @@ class TestTouch:
         await client.set(key_and_value, key_and_value)
         await client.touch(key_and_value, -1, noreply=True)
 
+        item = await client.get(key_and_value)
+        assert item is None
+
+
+class TestFlushAll:
+    @pytest.mark.skipif(sys.platform == "darwin", reason="https://github.com/memcached/memcached/issues/681")
+    @pytest.mark.parametrize("noreply", [False, True])
+    async def test_flush_all(self, client, key_generation, memcached_address_1, memcached_address_2, noreply):
+        key_and_value = next(key_generation)
+
+        # set a new key and value.
+        await client.set(key_and_value, key_and_value)
+
+        # flush all for all of the servers
+        await client.flush_all(memcached_address_1, noreply=noreply)
+        await client.flush_all(memcached_address_2, noreply=noreply)
+
+        # item should not be found.
+        item = await client.get(key_and_value)
+        assert item is None
+
+    async def test_flush_all_with_delay(self, client, key_generation, memcached_address_1, memcached_address_2):
+        key_and_value = next(key_generation)
+
+        # set a new key and value.
+        await client.set(key_and_value, key_and_value)
+
+        # flush all for all of the servers
+        await client.flush_all(memcached_address_1, delay=2)
+        await client.flush_all(memcached_address_2, delay=2)
+
+        # item should be found.
+        item = await client.get(key_and_value)
+        assert item is not None
+
+        # wait for delay time
+        await asyncio.sleep(2)
+
+        # item should not be found.
         item = await client.get(key_and_value)
         assert item is None

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -155,6 +155,14 @@ class TestCluster:
         assert list(nodes.keys())[0] == node1
         assert list(nodes.values())[0] == [b"key", b"key2"]
 
+    async def test_node(self, cluster_with_one_node, node1, memcached_host_address_1):
+        node = cluster_with_one_node.node(memcached_host_address_1)
+        assert node == node1
+
+    async def test_node_invalid_host(self, cluster_with_one_node):
+        with pytest.raises(ValueError):
+            cluster_with_one_node.node(MemcachedHostAddress(address="foo", port=1))
+
     async def test_unhealthy_not_purge_node(self, cluster_with_two_nodes, node1, node2):
         # Report that node2 is unhealthy
         cluster_with_two_nodes._on_node_healthy_status_change_cb(node2, False)


### PR DESCRIPTION
Flush all allows you to remove all of the keys of a Memcached server, emcache
provides the interface by asking first to which memcahced sever you want to
perform the operation.