### PR TITLE
Create connection latencies metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 NOT RELEASED YET
 =================
-- Add create connection latencies metrics
+- Add create connection latencies metrics [#54](https://github.com/pfreixes/emcache/pull/54)
 
 0.4.0
 ==========

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+NOT RELEASED YET
+=================
+- Add create connection latencies metrics
+
 0.4.0
 ==========
 - Stable version

--- a/docs/cluster_managment.rst
+++ b/docs/cluster_managment.rst
@@ -58,5 +58,9 @@ returned as attributes of this class are:
 - **operations_executed** Tells you how many operations have been executed.
 - **operations_executed_with_error** Tells you how many operations have been executed but ended up by having an exception during the execution.
 - **operations_waited** Tells you how many operations were delayed becausew they had to wait for an available connection.
+- **create_connection_avg** Tells you what's the average time that creating a connection took, using the last 100 observed values.
+- **create_connection_p50** Tells you what's the percentil 50 time for creating a connection, using the last 100 observed values.
+- **create_connection_p99** Tells you what's the percentil 99 time for creating a connection, using the last 100 observed values.
+- **create_connection_upper** Tells you what's the worst time that creating a connection took, using the last 100 observed values.
 
 These metrics can be push to a time series database for monitoring the execution of the Emcache driver, the user will need to take care of calculating the deltas, if the user is intereseted on them, of each historical value since historical values are accumulated values.

--- a/emcache/connection_pool.py
+++ b/emcache/connection_pool.py
@@ -44,7 +44,7 @@ class ConnectionPoolMetrics:
     operations_waited: int
 
     # Create connection latencies measured from the last,
-    # if there are, 1K observed values.
+    # if there are, 100 observed values.
     create_connection_avg: Optional[float]
     create_connection_p50: Optional[float]
     create_connection_p99: Optional[float]

--- a/emcache/connection_pool.py
+++ b/emcache/connection_pool.py
@@ -340,8 +340,8 @@ class ConnectionPool:
         metrics.cur_connections = self.total_connections
 
         # calculate the create connection latencies only if there
-        # there are latencies observed, otherwise default value which
-        # is None.
+        # are latencies observed, otherwise leave the default value
+        # which should be None.
         if self._create_connection_latencies:
             latencies = sorted(self._create_connection_latencies)
             metrics.create_connection_avg = sum(latencies) / len(latencies)

--- a/emcache/connection_pool.py
+++ b/emcache/connection_pool.py
@@ -4,7 +4,7 @@ import time
 from collections import deque
 from copy import copy
 from dataclasses import dataclass
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, List, Optional
 
 from .protocol import MemcacheAsciiProtocol, create_protocol
 
@@ -12,6 +12,9 @@ logger = logging.getLogger(__name__)
 
 CREATE_CONNECTION_MAX_BACKOFF = 60.0
 DECLARE_UNHEALTHY_CONNECTION_POOL_AFTER_RETRIES = 3
+
+
+_MAX_CREATE_CONNECTION_LATENCIES_OBSERVED = 100
 
 
 @dataclass
@@ -40,6 +43,13 @@ class ConnectionPoolMetrics:
     operations_executed_with_error: int
     operations_waited: int
 
+    # Create connection latencies measured from the last,
+    # if there are, 1K observed values.
+    create_connection_avg: Optional[float]
+    create_connection_p50: Optional[float]
+    create_connection_p99: Optional[float]
+    create_connection_upper: Optional[float]
+
 
 class ConnectionPool:
 
@@ -52,6 +62,7 @@ class ConnectionPool:
     _loop: asyncio.AbstractEventLoop
     _creating_connection_task: Optional[asyncio.Task]
     _create_connection_in_progress: bool
+    _create_connection_latencies: List[float]
     _connections_last_time_used: Dict[MemcacheAsciiProtocol, float]
     _purge_unused_connections_after: Optional[int]
     _total_purged_connections: int
@@ -83,6 +94,10 @@ class ConnectionPool:
             operations_executed=0,
             operations_executed_with_error=0,
             operations_waited=0,
+            create_connection_avg=None,
+            create_connection_p50=None,
+            create_connection_p99=None,
+            create_connection_upper=None,
         )
 
         # A connection pool starts always in a healthy state
@@ -103,6 +118,7 @@ class ConnectionPool:
         # attributes used for creating new connections
         self._creating_connection_task = None
         self._creating_connection = False
+        self._create_connection_latencies = []
 
         # attributes used for purging connections
         self._connections_last_time_used = {}
@@ -184,7 +200,16 @@ class ConnectionPool:
         """
         error = False
         try:
+            start = time.monotonic()
             connection = await create_protocol(self._host, self._port, timeout=self._connection_timeout)
+            elapsed = time.monotonic() - start
+
+            # record time elapsed and keep only the last N observed values
+            self._create_connection_latencies.append(elapsed)
+            self._create_connection_latencies = self._create_connection_latencies[
+                -_MAX_CREATE_CONNECTION_LATENCIES_OBSERVED:
+            ]
+
             self._connections_last_time_used[connection] = time.monotonic()
             self._total_connections += 1
             self._wakeup_next_waiter_or_append_to_unused(connection)
@@ -310,8 +335,20 @@ class ConnectionPool:
 
     def metrics(self) -> ConnectionPoolMetrics:
         metrics = copy(self._metrics)
+
         # current values are updated at read time
         metrics.cur_connections = self.total_connections
+
+        # calculate the create connection latencies only if there
+        # there are latencies observed, otherwise default value which
+        # is None.
+        if self._create_connection_latencies:
+            latencies = sorted(self._create_connection_latencies)
+            metrics.create_connection_avg = sum(latencies) / len(latencies)
+            metrics.create_connection_p50 = latencies[int((50 * len(latencies) / 100))]
+            metrics.create_connection_p99 = latencies[int((99 * len(latencies) / 100))]
+            metrics.create_connection_upper = latencies[-1]
+
         return metrics
 
     @property


### PR DESCRIPTION
Added new metrics for undestanding how long creating a connection takes, by
providing the following statistics: AVG, P50, P99 and upper.

Metrics are exposed as part of the connection pool metrics object which can
be gathered by using the `metrics()` method.