### PR TITLE
Make purging less aggressive, purge one connection per loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ NOT RELEASED YET
 =================
 - Add create connection latencies metrics [#54](https://github.com/pfreixes/emcache/pull/54)
 - Add new `min_connections` parameter [#55](https://github.com/pfreixes/emcache/pull/55)
+- Purge only one connection per loop iteration [#56](https://github.com/pfreixes/emcache/pull/56)
 
 0.4.0
 ==========

--- a/emcache/connection_pool.py
+++ b/emcache/connection_pool.py
@@ -180,6 +180,9 @@ class ConnectionPool:
             self._metrics.connections_purged += 1
             logger.info(f"{self} Connection purged")
 
+            # we purge one connection per loop iteration
+            break
+
         self._loop.call_later(self._purge_unused_connections_after, self._purge_unused_connections)
 
     def _wakeup_next_waiter_or_append_to_unused(self, connection):


### PR DESCRIPTION
Until now at each loop iteration for purging connections, Emcache could
decide to purge all eligible connections. With that change, we reduce the
number of purged connections to 1 per loop iteration.